### PR TITLE
Improved Maven colors

### DIFF
--- a/mvn-color
+++ b/mvn-color
@@ -21,15 +21,30 @@ export BACKGROUND_MAGENTA=`tput setab 5`
 export BACKGROUND_CYAN=`tput setab 6`
 export BACKGROUND_WHITE=`tput setab 7`
 export RESET_FORMATTING=`tput sgr0`
+
 # Wrapper function for Maven's mvn command.
-mvn-color(){
+mvn-color() {
 	# Filter mvn output using sed
 	mvn $@ | sed -e "s/\(\[INFO\]\ \-.*\)/${RESET_FORMATTING}\1/g" \
-	-e "s/\(\[INFO\]\ \[.*\)/${RESET_FORMATTING}${BOLD}\1${RESET_FORMATTING}/g" \
-	-e "s/\(\[INFO\]\ BUILD SUCCESSFUL\)/${BOLD}${TEXT_GREEN}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[INFO\] \[.*\)/${RESET_FORMATTING}${BOLD}\1${RESET_FORMATTING}/g" \
+	-e "s/\[INFO\] \(--- .* ---\)/\[INFO\] ${BOLD}${TEXT_MAGENTA}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[INFO\].*SUCCESS \[.*\]\)/${BOLD}${TEXT_GREEN}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[INFO\].*FAILURE \[.*\]\)/${BOLD}${TEXT_RED}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[INFO\].*SKIPPED\)/${BOLD}${TEXT_BLACK}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[INFO\] BUILD SUCCESS.*\)/${BOLD}${TEXT_GREEN}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[INFO\] BUILD FAILURE.*\)/${BOLD}${TEXT_RED}\1${RESET_FORMATTING}/g" \
 	-e "s/\(\[WARNING\].*\)/${BOLD}${TEXT_YELLOW}\1${RESET_FORMATTING}/g" \
 	-e "s/\(\[ERROR\].*\)/${BOLD}${TEXT_RED}\1${RESET_FORMATTING}/g" \
-	-e "s/Tests run: \([^,]*\), Failures: \([^,]*\), Errors: \([^,]*\), Skipped: \([^,]*\)/${BOLD}${TEXT_GREEN}Tests run: \1${RESET_FORMATTING}, Failures: ${BOLD}${TEXT_RED}\2${RESET_FORMATTING}, Errors: ${BOLD}${TEXT_RED}\3${RESET_FORMATTING}, Skipped: ${BOLD}${TEXT_YELLOW}\4${RESET_FORMATTING}/g"
+	-e "s/\(\[debug\].*\)/${TEXT_YELLOW}\1${RESET_FORMATTING}/g" \
+	-e "s/\(\[DEBUG\].*\)/${TEXT_YELLOW}\1${RESET_FORMATTING}/g" \
+	-e "s/\(Download.*\)/${BOLD}${TEXT_CYAN}\1${RESET_FORMATTING}/g" \
+	-e "s/Tests run: \(0\),/${BOLD}${TEXT_YELLOW}Tests run: \1${RESET_FORMATTING},/g" \
+	-e "s/Tests run: \([1-9][0-9]*\),/${BOLD}${TEXT_GREEN}Tests run: \1${RESET_FORMATTING},/g" \
+	-e "s/Failures: \([1-9][0-9]*\),/${BOLD}${TEXT_RED}Failures: \1${RESET_FORMATTING},/g" \
+	-e "s/Errors: \([1-9][0-9]*\),/${BOLD}${TEXT_RED}Errors: \1${RESET_FORMATTING},/g" \
+	-e "s/Skipped: \([1-9][0-9]*\)/${BOLD}${TEXT_YELLOW}Skipped: \1${RESET_FORMATTING}/g" \
+	-e "s/\(<<< FAILURE!.*\)/${BOLD}${TEXT_RED}\1${RESET_FORMATTING}/g"
+	
 	# Make sure formatting is reset
 	echo -ne ${RESET_FORMATTING}
 }


### PR DESCRIPTION
- more cases are colored now, including debug, download and build phases output;
- only non-zero failures, errors and skipped tests are colored to provide better visibility.
